### PR TITLE
Julia 0.7 compatibility

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,6 @@ JSON 0.7
 DocStringExtensions
 Requires
 LaTeXStrings
+Dates
+Compat
+Nullables

--- a/src/PlotlyBase.jl
+++ b/src/PlotlyBase.jl
@@ -68,8 +68,8 @@ function Plot(;style::Style=CURRENT_STYLE[])
     Plot(GenericTrace{Dict{Symbol,Any}}[], Layout(), Base.Random.uuid4(), style)
 end
 
-function Plot{T<:AbstractTrace}(data::AbstractVector{T}, layout=Layout();
-                                style::Style=CURRENT_STYLE[])
+function Plot(data::AbstractVector{T}, layout=Layout();
+              style::Style=CURRENT_STYLE[]) where T<:AbstractTrace
     Plot(data, layout, Base.Random.uuid4(), style)
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -35,7 +35,7 @@ for t in _TRACE_TYPES
     eval(Expr(:export, t))
 end
 
-Base.copy{HF<:HasFields}(hf::HF) = HF(deepcopy(hf.fields))
+Base.copy(hf::HF) where {HF<:HasFields} = HF(deepcopy(hf.fields))
 Base.copy(p::Plot) = Plot(AbstractTrace[copy(t) for t in p.data], copy(p.layout))
 fork(p::Plot) = Plot(deepcopy(p.data), copy(p.layout))
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -5,7 +5,7 @@
 prep_kwarg(pair::Union{Pair,Tuple}) =
     (Symbol(replace(string(pair[1]), "_", ".")), pair[2])
 prep_kwargs(pairs::AbstractVector) = Dict(map(prep_kwarg, pairs))
-prep_kwargs(pairs::Associative) = Dict(prep_kwarg((k, v)) for (k, v) in pairs)
+prep_kwargs(pairs::AbstractDict) = Dict(prep_kwarg((k, v)) for (k, v) in pairs)
 
 """
     size(::PlotlyBase.Plot)
@@ -29,7 +29,7 @@ for t in _TRACE_TYPES
     str_t = string(t)
     code = quote
         $t(;kwargs...) = GenericTrace($str_t; kwargs...)
-        $t(d::Associative; kwargs...) = GenericTrace($str_t, _symbol_dict(d); kwargs...)
+        $t(d::AbstractDict; kwargs...) = GenericTrace($str_t, _symbol_dict(d); kwargs...)
     end
     eval(code)
     eval(Expr(:export, t))
@@ -63,12 +63,12 @@ NOTE that the argument `i` here is _not_ the same as the argument `ind` below.
 apply the update to.
 
 =#
-function _apply_restyle_setindex!(hf::Union{Associative,HasFields}, k::Symbol,
+function _apply_restyle_setindex!(hf::Union{AbstractDict,HasFields}, k::Symbol,
                                   v::Union{AbstractArray,Tuple}, i::Int)
     setindex!(hf, v[i], k)
 end
 
-_apply_restyle_setindex!(hf::Union{Associative,HasFields}, k::Symbol, v, i::Int) =
+_apply_restyle_setindex!(hf::Union{AbstractDict,HasFields}, k::Symbol, v, i::Int) =
     setindex!(hf, v, k)
 
 
@@ -109,11 +109,11 @@ function _update_fields(hf::GenericTrace, i::Int, update::Dict=Dict(); kwargs...
 end
 
 """
-    relayout!(l::Layout, update::Associative=Dict(); kwargs...)
+    relayout!(l::Layout, update::AbstractDict=Dict(); kwargs...)
 
 Update `l` using update dict and/or kwargs
 """
-function relayout!(l::Layout, update::Associative=Dict(); kwargs...)
+function relayout!(l::Layout, update::AbstractDict=Dict(); kwargs...)
     merge!(l.fields, update)  # apply updates in the dict w/out `_` processing
     for (k,v) in kwargs
         setindex!(l, v, k)
@@ -122,37 +122,37 @@ function relayout!(l::Layout, update::Associative=Dict(); kwargs...)
 end
 
 """
-    relayout!(p::Plot, update::Associative=Dict(); kwargs...)
+    relayout!(p::Plot, update::AbstractDict=Dict(); kwargs...)
 
 Update `p.layout` on using update dict and/or kwargs
 """
-relayout!(p::Plot, update::Associative=Dict(); kwargs...) =
+relayout!(p::Plot, update::AbstractDict=Dict(); kwargs...) =
     relayout!(p.layout, update; kwargs...)
 
 """
-    restyle!(gt::GenericTrace, i::Int=1, update::Associative=Dict(); kwargs...)
+    restyle!(gt::GenericTrace, i::Int=1, update::AbstractDict=Dict(); kwargs...)
 
 Update trace `gt` using dict/kwargs, assuming it was the `i`th ind in a call
 to `restyle!(::Plot, ...)`
 """
-restyle!(gt::GenericTrace, i::Int=1, update::Associative=Dict(); kwargs...) =
+restyle!(gt::GenericTrace, i::Int=1, update::AbstractDict=Dict(); kwargs...) =
     _update_fields(gt, i, update; kwargs...)
 
 """
-    restyle!(p::Plot, ind::Int=1, update::Associative=Dict(); kwargs...)
+    restyle!(p::Plot, ind::Int=1, update::AbstractDict=Dict(); kwargs...)
 
 Update `p.data[ind]` using update dict and/or kwargs
 """
-restyle!(p::Plot, ind::Int, update::Associative=Dict(); kwargs...) =
+restyle!(p::Plot, ind::Int, update::AbstractDict=Dict(); kwargs...) =
     restyle!(p.data[ind], 1, update; kwargs...)
 
 """
-    restyle!(::Plot, ::AbstractVector{Int}, ::Associative=Dict(); kwargs...)
+    restyle!(::Plot, ::AbstractVector{Int}, ::AbstractDict=Dict(); kwargs...)
 
 Update specific traces at `p.data[inds]` using update dict and/or kwargs
 """
 function restyle!(p::Plot, inds::AbstractVector{Int},
-                  update::Associative=Dict(); kwargs...)
+                  update::AbstractDict=Dict(); kwargs...)
     N = length(inds)
     kw = Dict{Symbol,Any}(kwargs)
 
@@ -167,11 +167,11 @@ function restyle!(p::Plot, inds::AbstractVector{Int},
 end
 
 """
-    restyle!(p::Plot, update::Associative=Dict(); kwargs...)
+    restyle!(p::Plot, update::AbstractDict=Dict(); kwargs...)
 
 Update all traces using update dict and/or kwargs
 """
-restyle!(p::Plot, update::Associative=Dict(); kwargs...) =
+restyle!(p::Plot, update::AbstractDict=Dict(); kwargs...) =
     restyle!(p, 1:length(p.data), update; kwargs...)
 
 """
@@ -212,7 +212,7 @@ restyle!
 
 function update!(
         p::Plot, ind::Union{AbstractVector{Int},Int},
-        update::Associative=Dict(); layout::Layout=Layout(),
+        update::AbstractDict=Dict(); layout::Layout=Layout(),
         kwargs...
     )
     relayout!(p; layout.fields...)
@@ -390,7 +390,7 @@ extendtraces!(p, Dict("marker.size"=>Vector[[1, 3], [5, 5, 6]]), [3, 5], 10)
 ```
 
 """
-function extendtraces!(p::Plot, update::Associative, indices::Vector{Int}=[1],
+function extendtraces!(p::Plot, update::AbstractDict, indices::Vector{Int}=[1],
                        maxpoints=-1)
     # TODO: maxpoints not handled here
     for (ix, p_ix) in enumerate(indices)
@@ -403,14 +403,14 @@ function extendtraces!(p::Plot, update::Associative, indices::Vector{Int}=[1],
 end
 
 """
-    prependtraces!(p::Plot, update::Associative, indices::Vector{Int}=[1],
+    prependtraces!(p::Plot, update::AbstractDict, indices::Vector{Int}=[1],
                     maxpoints=-1)
                     
 The API for `prependtraces` is equivalent to that for `extendtraces` except that
 the data is added to the front of the traces attributes instead of the end. See
 Those docstrings for more information
 """
-function prependtraces!(p::Plot, update::Associative, indices::Vector{Int}=[1],
+function prependtraces!(p::Plot, update::AbstractDict, indices::Vector{Int}=[1],
                         maxpoints=-1)
     # TODO: maxpoints not handled here
     for (ix, p_ix) in enumerate(indices)
@@ -431,7 +431,7 @@ for f in (:extendtraces!, :prependtraces!)
         $(f)(p::Plot, ind::Int, maxpoints=-1; update...) =
             ($f)(p, [ind], maxpoints; update...)
 
-        $(f)(p::Plot, update::Associative, ind::Int, maxpoints=-1) =
+        $(f)(p::Plot, update::AbstractDict, ind::Int, maxpoints=-1) =
             ($f)(p, update, [ind], maxpoints)
     end
 end

--- a/src/convenience_api.jl
+++ b/src/convenience_api.jl
@@ -15,20 +15,20 @@ trace.
 columns (say `N`). Then `N` traces are constructed, where the `i`th column of
 `x` is paired with the `i`th column of `y`.
 """
-function Plot{T<:_Scalar}(x::AbstractVector{T}, y::AbstractVector, l::Layout=Layout();
-              kind="scatter", style::Style=CURRENT_STYLE[], kwargs...)
+function Plot(x::AbstractVector{T}, y::AbstractVector, l::Layout=Layout();
+              kind="scatter", style::Style=CURRENT_STYLE[], kwargs...) where T<:_Scalar
     Plot(GenericTrace(x, y; kind=kind, kwargs...), l, style=style)
 end
 
-function Plot{T<:_Scalar}(x::AbstractVector{T}, y::AbstractMatrix, l::Layout=Layout();
-              style::Style=CURRENT_STYLE[], kwargs...)
+function Plot(x::AbstractVector{T}, y::AbstractMatrix, l::Layout=Layout();
+              style::Style=CURRENT_STYLE[], kwargs...) where T<:_Scalar
     traces = GenericTrace[GenericTrace(x, view(y, :, i); kwargs...)
                           for i in 1:size(y, 2)]
     Plot(traces, l, style=style)
 end
 
-function Plot{T<:AbstractVector}(x::AbstractVector{T}, y::AbstractMatrix, l::Layout=Layout();
-              style::Style=CURRENT_STYLE[], kwargs...)
+function Plot(x::AbstractVector{T}, y::AbstractMatrix, l::Layout=Layout();
+              style::Style=CURRENT_STYLE[], kwargs...) where T<:AbstractVector
     size(x, 1) == size(y, 2) || error("x and y must have same number of cols")
 
     traces = GenericTrace[GenericTrace(x[i], view(y, :, i); kwargs...)
@@ -56,7 +56,7 @@ Build a scatter plot and set  `y` to y. All keyword arguments are passed directl
 as keyword arguments to the constructed scatter.
 """
 # AbstractArray{T,N}
-function Plot{T<:_Scalar}(y::AbstractArray{T}, l::Layout=Layout(); kwargs...)
+function Plot(y::AbstractArray{T}, l::Layout=Layout(); kwargs...) where T<:_Scalar
     # call methods above to get many traces if y is >1d
     Plot(1:size(y, 1), y, l; kwargs...)
 end

--- a/src/convenience_api.jl
+++ b/src/convenience_api.jl
@@ -50,12 +50,12 @@ function Plot(x::AbstractMatrix, y::AbstractMatrix, l::Layout=Layout();
     Plot(traces, l; style=style)
 end
 
+# AbstractArray{T,N}
 """
 $(SIGNATURES)
 Build a scatter plot and set  `y` to y. All keyword arguments are passed directly
 as keyword arguments to the constructed scatter.
 """
-# AbstractArray{T,N}
 function Plot(y::AbstractArray{T}, l::Layout=Layout(); kwargs...) where T<:_Scalar
     # call methods above to get many traces if y is >1d
     Plot(1:size(y, 1), y, l; kwargs...)

--- a/src/dataframes_api.jl
+++ b/src/dataframes_api.jl
@@ -1,7 +1,7 @@
 import DataFrames.AbstractDataFrame
 using DataFrames
 
-@require Revise begin
+@require Revise="295af30f-e4ad-537b-8983-00126c2a3abe" begin
     Revise.track(PlotlyBase, @__FILE__)
 end
 

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -1,6 +1,6 @@
 using Distributions
 
-@require Revise begin
+@require Revise="295af30f-e4ad-537b-8983-00126c2a3abe" begin
     Revise.track(PlotlyBase, @__FILE__)
 end
 

--- a/src/json.jl
+++ b/src/json.jl
@@ -95,11 +95,11 @@ end
 
 # Let string interpolation stringify to JSON format
 Base.print(io::IO, a::Union{Shape,GenericTrace,PlotlyAttribute,Layout,Plot}) = print(io, JSON.json(a))
-Base.print{T<:GenericTrace}(io::IO, a::Vector{T}) = print(io, JSON.json(a))
+Base.print(io::IO, a::Vector{T}) where {T<:GenericTrace} = print(io, JSON.json(a))
 
 GenericTrace(d::Associative{Symbol}) = GenericTrace(pop!(d, :type, "scatter"), d)
-GenericTrace{T<:AbstractString}(d::Associative{T}) = GenericTrace(_symbol_dict(d))
-Layout{T<:AbstractString}(d::Associative{T}) = Layout(_symbol_dict(d))
+GenericTrace(d::Associative{T}) where {T<:AbstractString} = GenericTrace(_symbol_dict(d))
+Layout(d::Associative{T}) where {T<:AbstractString} = Layout(_symbol_dict(d))
 
 function JSON.parse(::Type{Plot}, str::AbstractString)
     d = JSON.parse(str)

--- a/src/recession_bands.jl
+++ b/src/recession_bands.jl
@@ -30,7 +30,7 @@ end
 
 to_date(x::Union{Integer,Dates.TimeType}) = Nullable(Date(x))
 
-function to_date{T,N}(x::AbstractArray{T,N})
+function to_date(x::AbstractArray{T,N}) where {T,N}
     out_arr = Array{Date}(0)
 
     for i in x
@@ -44,7 +44,7 @@ function to_date{T,N}(x::AbstractArray{T,N})
     Nullable(reshape(out_arr, size(x)))
 end
 
-function to_date{T<:Dates.TimeType,N}(x::AbstractArray{T,N})
+function to_date(x::AbstractArray{T,N}) where {T<:Dates.TimeType,N}
     Nullable(map(Date, x))
 end
 

--- a/src/recession_bands.jl
+++ b/src/recession_bands.jl
@@ -31,7 +31,7 @@ end
 to_date(x::Union{Integer,Dates.TimeType}) = Nullable(Date(x))
 
 function to_date(x::AbstractArray{T,N}) where {T,N}
-    out_arr = Array{Date}(0)
+    out_arr = Date[]
 
     for i in x
         maybe_date = to_date(i)

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -26,7 +26,7 @@ function gen_layout(nr, nc, subplot_titles::Bool=false)
 
         y = 1.0 # reset y as we start a new col
         for row in 1:nr
-            subplot = sub2ind((nc, nr), col, row)
+            subplot = LinearIndices((nc, nr))[col, row]
 
             out["xaxis$subplot"] = Dict{Any,Any}(:domain=>[x, x+w],
                                                  :anchor=> "y$subplot")
@@ -84,7 +84,7 @@ function _cat(nr::Int, nc::Int, ps::Plot...)
     layout = gen_layout(nr, nc, subplot_titles)
 
     for col in 1:nc, row in 1:nr
-        ix = sub2ind((nc, nr), col, row)
+        ix = LinearIndices((nc, nr))[col, row]
         handle_titles!(layout, copied_plots[ix].layout, ix)
         layout["xaxis$ix"] = merge(copied_plots[ix].layout["xaxis"], layout["xaxis$ix"])
         layout["yaxis$ix"] = merge(copied_plots[ix].layout["yaxis"], layout["yaxis$ix"])

--- a/src/traces_layouts.jl
+++ b/src/traces_layouts.jl
@@ -19,14 +19,14 @@ const _layout_defaults = Dict{Symbol,Any}(:margin => Dict(:l=>50, :r=>50, :t=>60
 mutable struct Layout{T<:Associative{Symbol,Any}} <: AbstractLayout
     fields::T
 
-    function (::Type{Layout{T}}){T}(fields::T; kwargs...)
+    function Layout{T}(fields::T; kwargs...) where T
         l = new{T}(merge(_layout_defaults, fields))
         map(x->setindex!(l, x[2], x[1]), kwargs)
         l
     end
 end
 
-Layout{T<:Associative{Symbol,Any}}(fields::T=Dict{Symbol,Any}(); kwargs...) =
+Layout(fields::T=Dict{Symbol,Any}(); kwargs...) where {T<:Associative{Symbol,Any}} =
     Layout{T}(fields; kwargs...)
 
 kind(gt::GenericTrace) = get(gt, :type, "scatter")
@@ -195,7 +195,7 @@ end
 
 Base.haskey(hf::HasFields, k::Symbol) = haskey(hf.fields, k)
 
-Base.merge{T<:HasFields}(hf1::T, hf2::T) =
+Base.merge(hf1::T, hf2::T) where {T<:HasFields} =
     merge!(deepcopy(hf1), hf2)
 
 Base.isempty(hf::HasFields) = isempty(hf.fields)
@@ -209,7 +209,7 @@ Base.start(hf::HasFields) = start(hf.fields)
 Base.next(hf::HasFields, x) = next(hf.fields, x)
 Base.done(hf::HasFields, x) = done(hf.fields, x)
 
-=={T<:HasFields}(hf1::T, hf2::T) = hf1.fields == hf2.fields
+==(hf1::T, hf2::T) where {T<:HasFields} = hf1.fields == hf2.fields
 
 # methods that allow you to do `obj["first.second.third"] = val`
 function Base.setindex!(gt::HasFields, val, key::String)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-TestSetExtensions 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,52 @@
 module PlotlyBaseTest
-using TestSetExtensions
 
-using Base.Test
+using Compat.Test
+using Dates
+using Nullables
+
+@static if VERSION >= v"0.7.0-alpha"
+    using DelimitedFiles: readdlm
+end
+
 
 using PlotlyBase
 const M = PlotlyBase
 
-try
-    @testset ExtendedTestSet "PlotlyJS Tests" begin
+# copied from TestSetExtensions.@includetests
+macro includetests(testarg...)
+    if length(testarg) == 0
+        tests = []
+    elseif length(testarg) == 1
+        tests = testarg[1]
+    else
+        error("@includetests takes zero or one argument")
+    end
+
+    quote
+        tests = $tests
+        rootfile = @__FILE__
+        if length(tests) == 0
+            tests = readdir(dirname(rootfile))
+            tests = filter(f->endswith(f, ".jl") && f!= basename(rootfile), tests)
+        else
+            tests = map(f->string(f, ".jl"), tests)
+        end
+        println();
+        for test in tests
+            print(splitext(test)[1], ": ")
+            include(test)
+            println()
+        end
+    end
+end
+
+
+#try
+    @testset "PlotlyJS Tests" begin
         @includetests ARGS
     end
-catch
-    exit(-1)
-end
+#catch
+#    exit(-1)
+#end
 
 end


### PR DESCRIPTION
This commit tries to make PlotlyBase compatible with 0.7.

- Femtocleaner did a good job fixing deprecated syntax and a few functions.
- The rest was cleaned up by hand.
Tests succesfully run in 0.6 and 0.7 (1 day old master branch).

A few notes:
- Some `Compat` packages are used instead of depending on the new stdlib packages, can be dropped at some later point.
- Still using `Nullable` instead of something like `Union{T, Missing}` to not hamper 0.6.
- Usage of `TestSetExtensions` was dropped, I could not get it easily running in 0.7, can be added back later.