### PR TITLE
Updating the warn function for Julia v1.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ JSON 0.7
 DocStringExtensions
 Requires
 LaTeXStrings
+Logging

--- a/src/PlotlyBase.jl
+++ b/src/PlotlyBase.jl
@@ -6,6 +6,7 @@ using DocStringExtensions
 using Requires
 using UUIDs
 using Dates
+using Logging
 
 import Base: ==
 

--- a/src/convenience_api.jl
+++ b/src/convenience_api.jl
@@ -69,7 +69,7 @@ keyword arguments are applied to the constructed trace.
 function Plot(f::Function, x0::Number, x1::Number, l::Layout=Layout();
               style::Style=CURRENT_STYLE[],
               kwargs...)
-    x = linspace(x0, x1, 50)
+    x = LinRange(x0, x1, 50)
     y = [f(_) for _ in x]
     Plot(GenericTrace(x, y; name=Symbol(f), kwargs...), l, style=style)
 end
@@ -84,7 +84,7 @@ function Plot(fs::AbstractVector{Function}, x0::Number, x1::Number,
               l::Layout=Layout();
               style::Style=CURRENT_STYLE[],
               kwargs...)
-    x = linspace(x0, x1, 50)
+    x = LinRange(x0, x1, 50)
     traces = GenericTrace[GenericTrace(x, map(f, x); name=Symbol(f), kwargs...)
                           for f in fs]
     Plot(traces, l; style=style)

--- a/src/convenience_api.jl
+++ b/src/convenience_api.jl
@@ -69,7 +69,7 @@ keyword arguments are applied to the constructed trace.
 function Plot(f::Function, x0::Number, x1::Number, l::Layout=Layout();
               style::Style=CURRENT_STYLE[],
               kwargs...)
-    x = LinRange(x0, stop=x1, length=50)
+    x = range(x0, stop=x1, length=50)
     y = [f(_) for _ in x]
     Plot(GenericTrace(x, y; name=Symbol(f), kwargs...), l, style=style)
 end
@@ -84,7 +84,7 @@ function Plot(fs::AbstractVector{Function}, x0::Number, x1::Number,
               l::Layout=Layout();
               style::Style=CURRENT_STYLE[],
               kwargs...)
-    x = LinRange(x0, stop=x1, length=50)
+    x = range(x0, stop=x1, length=50)
     traces = GenericTrace[GenericTrace(x, map(f, x); name=Symbol(f), kwargs...)
                           for f in fs]
     Plot(traces, l; style=style)

--- a/src/convenience_api.jl
+++ b/src/convenience_api.jl
@@ -69,7 +69,7 @@ keyword arguments are applied to the constructed trace.
 function Plot(f::Function, x0::Number, x1::Number, l::Layout=Layout();
               style::Style=CURRENT_STYLE[],
               kwargs...)
-    x = LinRange(x0, x1, 50)
+    x = LinRange(x0, stop=x1, length=50)
     y = [f(_) for _ in x]
     Plot(GenericTrace(x, y; name=Symbol(f), kwargs...), l, style=style)
 end
@@ -84,7 +84,7 @@ function Plot(fs::AbstractVector{Function}, x0::Number, x1::Number,
               l::Layout=Layout();
               style::Style=CURRENT_STYLE[],
               kwargs...)
-    x = LinRange(x0, x1, 50)
+    x = LinRange(x0, stop=x1, length=50)
     traces = GenericTrace[GenericTrace(x, map(f, x); name=Symbol(f), kwargs...)
                           for f in fs]
     Plot(traces, l; style=style)

--- a/src/dataframes_api.jl
+++ b/src/dataframes_api.jl
@@ -43,7 +43,9 @@ function GenericTrace(df::DataFrames.AbstractDataFrame; group=nothing, kind="sca
         end
         return GenericTrace[t for t in _traces[:x1]]
     else
-        (group !== nothing) && warn("Unknown group $(group), skipping")
+        if (group == nothing)
+            @warn "Unknown group $(group), skipping"
+        end
     end
 
     for (k, v) in d

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -27,6 +27,9 @@ function Base.getindex(c::Cycler, ixs::AbstractVector{<:Integer})
     [c[i] for i in ixs]
 end
 
+Base.iterate(c::Cycler, s::Int=1) = c[s], s+1
+Base.IteratorSize(::Cycler) = IsInfinite()
+
 struct Style
     layout::Layout
     global_trace::PlotlyAttribute

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -43,13 +43,13 @@ function Style(;
     )
     if !isempty(color_cycle)
         msg = """
-        `color_cycle` argument deprecated. Set the `marker_color` attrbute
+        `color_cycle` argument deprecated. Set the `marker_color` attribute
         on `global_trace` instead using a Cycler like this:
 
         Style(global_trace=attr(marker_color=Cycler($(color_cycle))))
         """
         global_trace[:marker_color] = Cycler(color_cycle)
-        warn(msg)
+        @warn msg
     end
     Style(layout, global_trace, trace)
 end


### PR DESCRIPTION
Julia v1.0 uses the [Logging](https://docs.julialang.org/en/v1/stdlib/Logging/index.html) package and a [macro for warn](https://docs.julialang.org/en/v1/stdlib/Logging/index.html).

I updated two Julia files + added `using Logging` in `PlotlyBase.jl` and `REQUIRE`.

**Not fully tested**

