### PR TITLE
Remove `init_notebook` export

### DIFF
--- a/src/PlotlyBase.jl
+++ b/src/PlotlyBase.jl
@@ -89,9 +89,6 @@ export
     # convenience stuff
     add_recession_bands!,
 
-    # frontend methods
-    init_notebook,
-
     # styles
     use_style!, style, Style, Cycler,
 


### PR DESCRIPTION
This doesn't seem to be defined anymore