### PR TITLE
change min/max to min./max. in stem

### DIFF
--- a/src/convenience_api.jl
+++ b/src/convenience_api.jl
@@ -104,8 +104,8 @@ Creates a "stem" or "lollipop" trace. It is implemented using plotly.js's
 * stem_thickness - sets the thickness of the stems
 """
 function stem(;y=nothing, stem_color="grey", stem_thickness=1, kwargs...)
-    line_up = -min(y, 0)
-    line_down = max(y, 0)
+    line_up = -min.(y, 0)
+    line_down = max.(y, 0)
     trace = scatter(; y=y, text=y, marker_size=10, mode="markers", hoverinfo="text", kwargs...)
     trace.fields[:error_y] = Dict(
         :type => "data",


### PR DESCRIPTION
currently `stem` fails with this simple example:

    using PlotlyJS
    x = [1,2,3]
    y = [1,-1,1]
    stem(;x=x, y=y)

this pull request fixes the issue by changing `min` and `max` to the elementwise `min.` and `max.`