### PR TITLE
Fix DataFrames v0.19 deprecations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,12 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 JSON = "≥ 0.7.0"
 julia = "≥ 1.0.0"
+DataFrames = "≥ 0.19.0"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/src/dataframes_api.jl
+++ b/src/dataframes_api.jl
@@ -1,9 +1,9 @@
 # utilities
 
 _has_group(df::DataFrames.AbstractDataFrame, group::Any) = false
-_has_group(df::DataFrames.AbstractDataFrame, group::Symbol) = haskey(df, group)
+_has_group(df::DataFrames.AbstractDataFrame, group::Symbol) = hasproperty(df, group)
 function _has_group(df::DataFrames.AbstractDataFrame, group::Vector{Symbol})
-    all(x -> haskey(df, x), group)
+    all(x -> hasproperty(df, x), group)
 end
 
 _group_name(df::DataFrames.AbstractDataFrame, group::Symbol) = df[1, group]
@@ -26,7 +26,7 @@ applied to all traces
 Also, when using this routine you can pass a function as a value for any
 keyword argument. This function will be replaced by calling the function on the
 DataFrame. For example, if I were to pass `name=(df) -> "Wage (average =
-\$(mean(df[:X1])))"` then the `name` attribute on the trace would be replaced by
+\$(mean(df[!, :X1])))"` then the `name` attribute on the trace would be replaced by
 the  `Wage (average = XX)`, where `XX` is the average of the `X1` column in the
 DataFrame.
 
@@ -49,8 +49,8 @@ function GenericTrace(df::DataFrames.AbstractDataFrame; group=nothing, kind="sca
     end
 
     for (k, v) in d
-        if isa(v, Symbol) && haskey(df, v)
-            d[k] = df[v]
+        if isa(v, Symbol) && hasproperty(df, v)
+            d[k] = df[!, v]
         elseif isa(v, Function)
             d[k] = v(df)
         end


### PR DESCRIPTION
Switches from `haskey(df, colname)` to `hasproperty(df, colname)` and from `df[colname]` to `df[!, colname]`.
I guess that requires DataFrames v0.19 (or a bit earlier), but since it's an optional dependency, the check has yet to be coded in `__init__()`, which I can try to implement if needed.
