### PR TITLE
Plotly fixed version

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -40,7 +40,7 @@ function savehtml(io::IO, p::Plot)
     print(io, """
     <html>
     <head>
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-1.54.7.min.js"></script>
     </head>
     <body>
       $(html_body(p))


### PR DESCRIPTION
Currently, PlotlyBase.jl loads `https://cdn.plot.ly/plotly-latest.min.js`, which is an unbounded dependency of this project - when plotly releases `2.0`, for example, Julia code using PlotlyBase.jl might no longer work - even if their dependency on `PlotlyBase.jl` has its version fixed.

To keep getting plotly's latest features, you could (test and) update the dependency version inside `PlotlyBase.jl` whenever you see fit.