### PR TITLE
ENH: integrate kaleido to save/export figures

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,10 +1,19 @@
 [[kaleido]]
 arch = "x86_64"
-git-tree-sha1 = "1e353e4855a97139897f46e86d3a46a190e3f119"
+git-tree-sha1 = "eaf6781d8951eda81e75724d9c53b719e680ff30"
+libc = "glibc"
+os = "linux"
+
+    [[kaleido.download]]
+    sha256 = "5ac2071a3b8994a25c854cedc84bcf5b1a90e7aee2347de45f778bbb264fdd6a"
+    url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_linux.tar.gz"
+[[kaleido]]
+arch = "x86_64"
+git-tree-sha1 = "446336b110990287685afab2806bec8ab562b360"
 os = "macos"
 
     [[kaleido.download]]
-    sha256 = "b46878e79557a68afaeae0b5ab96b0209da4c1849804579454dd42bd86eed51a"
+    sha256 = "d7666898169d7e95564669b96860346c85b5f10a1561f073cd026cc9658b16df"
     url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_mac.tar.gz"
 [[kaleido]]
 arch = "x86_64"
@@ -12,13 +21,5 @@ git-tree-sha1 = "c959551ad0b7f5c1c33b9cb31baa203bcad3a1af"
 os = "windows"
 
     [[kaleido.download]]
-    sha256 = "7555bfeae05f2ff810c786e4cd7c438159d7408446e2f98c41e8bdc09415ff6d"
+    sha256 = "9013a52c621293247331bd8280df95e73e3d30c313de378c1524c0c0707e13dd"
     url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_win.tar.gz"
-[[kaleido]]
-arch = "x86_64"
-git-tree-sha1 = "eaf6781d8951eda81e75724d9c53b719e680ff30"
-os = "linux"
-
-    [[kaleido.download]]
-    sha256 = "89920b9a4fe8d435ee5a56fb6b31875b03707ad46752310a0a35cb2411b7a2c0"
-    url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_linux.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -16,8 +16,7 @@ os = "windows"
     url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_win.tar.gz"
 [[kaleido]]
 arch = "x86_64"
-git-tree-sha1 = "1b00b3c57045b5aa6f088ada460410b67e69d92e"
-libc = "glibc"
+git-tree-sha1 = "eaf6781d8951eda81e75724d9c53b719e680ff30"
 os = "linux"
 
     [[kaleido.download]]

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -8,17 +8,18 @@ os = "macos"
     url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_mac.tar.gz"
 [[kaleido]]
 arch = "x86_64"
-git-tree-sha1 = "1b00b3c57045b5aa6f088ada460410b67e69d92e"
-os = "linux"
-
-    [[kaleido.download]]
-    sha256 = "e567f434535a6a92bbff1ce0457fa56703f531ded28804e694f1900c14ce7e42"
-    url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_linux.tar.gz"
-[[kaleido]]
-arch = "x86_64"
 git-tree-sha1 = "c959551ad0b7f5c1c33b9cb31baa203bcad3a1af"
 os = "windows"
 
     [[kaleido.download]]
     sha256 = "7555bfeae05f2ff810c786e4cd7c438159d7408446e2f98c41e8bdc09415ff6d"
     url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_win.tar.gz"
+[[kaleido]]
+arch = "x86_64"
+git-tree-sha1 = "1b00b3c57045b5aa6f088ada460410b67e69d92e"
+libc = "glibc"
+os = "linux"
+
+    [[kaleido.download]]
+    sha256 = "89920b9a4fe8d435ee5a56fb6b31875b03707ad46752310a0a35cb2411b7a2c0"
+    url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_linux.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,24 @@
+[[kaleido]]
+arch = "x86_64"
+git-tree-sha1 = "1e353e4855a97139897f46e86d3a46a190e3f119"
+os = "macos"
+
+    [[kaleido.download]]
+    sha256 = "b46878e79557a68afaeae0b5ab96b0209da4c1849804579454dd42bd86eed51a"
+    url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_mac.tar.gz"
+[[kaleido]]
+arch = "x86_64"
+git-tree-sha1 = "1b00b3c57045b5aa6f088ada460410b67e69d92e"
+os = "linux"
+
+    [[kaleido.download]]
+    sha256 = "e567f434535a6a92bbff1ce0457fa56703f531ded28804e694f1900c14ce7e42"
+    url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_linux.tar.gz"
+[[kaleido]]
+arch = "x86_64"
+git-tree-sha1 = "c959551ad0b7f5c1c33b9cb31baa203bcad3a1af"
+os = "windows"
+
+    [[kaleido.download]]
+    sha256 = "7555bfeae05f2ff810c786e4cd7c438159d7408446e2f98c41e8bdc09415ff6d"
+    url = "https://github.com/sglyon/PlotlyBase.jl/releases/download/v0.3.1/kaleido_win.tar.gz"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -126,9 +126,9 @@ version = "0.9.2"
 
 [[Zlib_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "d5bba6485811931e4b8958e2d7ca3738273ac468"
+git-tree-sha1 = "622d8b6dc0c7e8029f17127703de9819134d1b71"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+15"
+version = "1.2.11+14"
 
 [[ghr_jll]]
 deps = ["Libdl", "Pkg"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -44,6 +44,7 @@ uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 version = "1.0.3"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -64,7 +65,7 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -116,3 +117,21 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[ZipFile]]
+deps = ["Libdl", "Printf", "Zlib_jll"]
+git-tree-sha1 = "254975fef2fc526583bb9b7c9420fe66ffe09f2f"
+uuid = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+version = "0.9.2"
+
+[[Zlib_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "d5bba6485811931e4b8958e2d7ca3738273ac468"
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.11+15"
+
+[[ghr_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "a842af97ca0010aedcfd765a4dfcfe403732a929"
+uuid = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
+version = "0.13.0+0"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -117,21 +117,3 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[ZipFile]]
-deps = ["Libdl", "Printf", "Zlib_jll"]
-git-tree-sha1 = "254975fef2fc526583bb9b7c9420fe66ffe09f2f"
-uuid = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
-version = "0.9.2"
-
-[[Zlib_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "d5bba6485811931e4b8958e2d7ca3738273ac468"
-uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+15"
-
-[[ghr_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a842af97ca0010aedcfd765a4dfcfe403732a929"
-uuid = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
-version = "0.13.0+0"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -126,9 +126,9 @@ version = "0.9.2"
 
 [[Zlib_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "622d8b6dc0c7e8029f17127703de9819134d1b71"
+git-tree-sha1 = "d5bba6485811931e4b8958e2d7ca3738273ac468"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+14"
+version = "1.2.11+15"
 
 [[ghr_jll]]
 deps = ["Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,25 +3,30 @@ uuid = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 version = "0.3.1"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
-JSON = "≥ 0.7.0"
-julia = "≥ 1.0.0"
 DataFrames = "≥ 0.19.0"
+JSON = "≥ 0.7.0"
+ZipFile = "≥ 0.9.2"
+julia = "≥ 1.3.0"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,9 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
-ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
-DataFrames = "≥ 0.19.0"
 JSON = "≥ 0.7.0"
-ZipFile = "≥ 0.9.2"
 julia = "≥ 1.3.0"
 
 [extras]

--- a/create_artifact_script.jl
+++ b/create_artifact_script.jl
@@ -12,9 +12,10 @@ function unzip(zf_path, dest_path)
     rm(k_path , force=true, recursive=true)
     mkdir(k_path)
     for f in r.files
+        @show f
         out_path = joinpath(dest_path, f.name)
-        if (endswith(f.name, "/") || endswith(f.name, "\\")) && !(isdir(out_path))
-            mkdir(out_path)
+        if (endswith(f.name, "/") || endswith(f.name, "\\"))
+            !isdir(out_path) && mkdir(out_path)
         else
             parent_dir = joinpath(dest_path, dirname(f.name))
             if !isdir(parent_dir)
@@ -48,17 +49,19 @@ function download_kaleido(k_dir, os=_download_os())
     download(url, dest)
     unzip(dest, k_dir)
     rm(dest)  # remove zip file
-    if Sys.islinux()
+    if Sys.isunix() && (os ∈ ["mac", "linux"])
         ex1_path = joinpath(k_dir, "kaleido", "kaleido")
         run(`chmod +x $ex1_path`)
 
-        ex1_path = joinpath(k_dir, "kaleido", "bin", "kaleido")
+        ex2_path = joinpath(k_dir, "kaleido", "bin", "kaleido")
         run(`chmod +x $ex2_path`)
     end
     return
 end
 
 for platform in [Linux(:x86_64), MacOS(:x86_64), Windows(:x86_64)]
+# for platform in [MacOS(:x86_64)]
+    @show platform
     kaleido_hash = artifact_hash("kaleido", artifact_toml, platform=platform)
     # If the name was not bound, or the hash it was bound to does not exist, create it!
     if kaleido_hash === nothing || !artifact_exists(kaleido_hash)

--- a/create_artifact_script.jl
+++ b/create_artifact_script.jl
@@ -13,7 +13,7 @@ function unzip(zf_path, dest_path)
     mkdir(k_path)
     for f in r.files
         out_path = joinpath(dest_path, f.name)
-        if (endswith(f.name, "/") || endswith(f.name, "\\")) && !(isdir(f.name))
+        if (endswith(f.name, "/") || endswith(f.name, "\\")) && !(isdir(out_path))
             mkdir(out_path)
         else
             parent_dir = joinpath(dest_path, dirname(f.name))
@@ -48,10 +48,17 @@ function download_kaleido(k_dir, os=_download_os())
     download(url, dest)
     unzip(dest, k_dir)
     rm(dest)  # remove zip file
+    if Sys.islinux()
+        ex1_path = joinpath(k_dir, "kaleido", "kaleido")
+        run(`chmod +x $ex1_path`)
+
+        ex1_path = joinpath(k_dir, "kaleido", "bin", "kaleido")
+        run(`chmod +x $ex2_path`)
+    end
     return
 end
 
-for platform in [Windows(:x86_64),]
+for platform in [Linux(:x86_64), MacOS(:x86_64), Windows(:x86_64)]
     kaleido_hash = artifact_hash("kaleido", artifact_toml, platform=platform)
     # If the name was not bound, or the hash it was bound to does not exist, create it!
     if kaleido_hash === nothing || !artifact_exists(kaleido_hash)
@@ -67,7 +74,7 @@ for platform in [Windows(:x86_64),]
         gz_path = joinpath(dir, gz_name)
         tarball_hash = archive_artifact(kaleido_hash, gz_path)
         ghr() do ghr
-            run(`$(ghr) -u sglyon -r PlotlyBase.jl $(release_tag) $(gz_path)`)
+            run(`$(ghr) -u sglyon -r PlotlyBase.jl -replace $(release_tag) $(gz_path)`)
         end
     end
     bind_artifact!(
@@ -75,6 +82,7 @@ for platform in [Windows(:x86_64),]
         "kaleido",
         kaleido_hash;
         platform=platform,
+        force=true,
         download_info = [
             ("https://github.com/sglyon/PlotlyBase.jl/releases/download/$(release_tag)/$(gz_name)", tarball_hash),
         ],

--- a/create_artifact_script.jl
+++ b/create_artifact_script.jl
@@ -1,0 +1,82 @@
+using Pkg.Artifacts, ghr_jll
+using Pkg.BinaryPlatforms
+import ZipFile
+
+release_tag = "v0.3.1"
+
+artifact_toml = joinpath(@__DIR__, "Artifacts.toml")
+
+function unzip(zf_path, dest_path)
+    r = ZipFile.Reader(zf_path)
+    k_path = joinpath(dest_path, "kaleido")
+    rm(k_path , force=true, recursive=true)
+    mkdir(k_path)
+    for f in r.files
+        out_path = joinpath(dest_path, f.name)
+        if (endswith(f.name, "/") || endswith(f.name, "\\")) && !(isdir(f.name))
+            mkdir(out_path)
+        else
+            parent_dir = joinpath(dest_path, dirname(f.name))
+            if !isdir(parent_dir)
+                mkpath(parent_dir)
+            end
+            v = Vector{UInt8}(undef, f.uncompressedsize)
+            read!(f, v)
+            write(out_path, v)
+        end
+    end
+    close(r)
+end
+
+_download_os(::Linux) = "linux"
+_download_os(::MacOS) = "mac"
+_download_os(::Windows) = "win"
+
+function _download_os()
+    if Sys.isunix()
+        return Sys.isapple() ? "mac" : "linux"
+    end
+    if Sys.iswindows()
+        return "win"
+    end
+    error("Only mac, linux, and windows are supported")
+end
+
+function download_kaleido(k_dir, os=_download_os())
+    url = "https://github.com/plotly/Kaleido/releases/download/v0.0.3/kaleido_$os-0.0.3.zip"
+    dest = joinpath(k_dir, "kaleido.zip")
+    download(url, dest)
+    unzip(dest, k_dir)
+    rm(dest)  # remove zip file
+    return
+end
+
+for platform in [Windows(:x86_64),]
+    kaleido_hash = artifact_hash("kaleido", artifact_toml, platform=platform)
+    # If the name was not bound, or the hash it was bound to does not exist, create it!
+    if kaleido_hash === nothing || !artifact_exists(kaleido_hash)
+        # create_artifact() returns the content-hash of the artifact directory once we're finished creating it
+        kaleido_hash = create_artifact() do k_dir
+            download_kaleido(k_dir, _download_os(platform))
+        end
+    end
+
+    local tarball_hash
+    gz_name = "kaleido_$(_download_os(platform)).tar.gz"
+    mktempdir() do dir
+        gz_path = joinpath(dir, gz_name)
+        tarball_hash = archive_artifact(kaleido_hash, gz_path)
+        ghr() do ghr
+            run(`$(ghr) -u sglyon -r PlotlyBase.jl $(release_tag) $(gz_path)`)
+        end
+    end
+    bind_artifact!(
+        artifact_toml,
+        "kaleido",
+        kaleido_hash;
+        platform=platform,
+        download_info = [
+            ("https://github.com/sglyon/PlotlyBase.jl/releases/download/$(release_tag)/$(gz_name)", tarball_hash),
+        ],
+    )
+end

--- a/src/PlotlyBase.jl
+++ b/src/PlotlyBase.jl
@@ -7,6 +7,8 @@ using Requires
 using UUIDs
 using Dates
 using Logging
+using Base64
+using Pkg.Artifacts
 
 import Base: ==
 
@@ -47,6 +49,7 @@ include("api.jl")
 include("convenience_api.jl")
 include("recession_bands.jl")
 include("output.jl")
+include("kaleido.jl")
 
 # Set some defaults for constructing `Plot`s
 function Plot(;style::Style=CURRENT_STYLE[])
@@ -101,6 +104,7 @@ function __init__()
         global DEFAULT_STYLE
         DEFAULT_STYLE[] = Style(env_style)
     end
+    _start_kaleido_process()
     @require IJulia="7073ff75-c697-5162-941a-fcdaad2a7d2a" begin
         function IJulia.display_dict(p::Plot)
             Dict(
@@ -113,6 +117,5 @@ function __init__()
     @require Distributions="31c24e10-a181-5473-b8eb-7969acd0382f" include("distributions.jl")
     @require Colors="5ae59095-9a9b-59fe-a467-6f913c188581" JSON.lower(a::Colors.Colorant) = string("#", Colors.hex(a))
 end
-
 
 end # module

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -1,0 +1,151 @@
+const BIN = `$(joinpath(artifact"kaleido", "kaleido", "kaleido")) plotly --disable-gpu`
+
+mutable struct Pipes
+    stdin::Pipe
+    stdout::Pipe
+    stderr::Pipe
+    proc::Base.Process
+    Pipes() = new()
+end
+
+const P = Pipes()
+
+const ALL_FORMATS = ["png", "jpg", "jpeg", "webp", "svg", "pdf", "eps", "json"]
+const TEXT_FORMATS = ["svg", "json", "eps"]
+
+function _restart_kaleido_process()
+    if process_running(P.proc)
+        kill(P.proc)
+    end
+    _start_kaleido_process()
+end
+
+
+function _start_kaleido_process()
+    global P
+    try
+        kstdin = Pipe()
+        kstdout = Pipe()
+        kstderr = Pipe()
+        kproc = run(pipeline(BIN,
+                             stdin = kstdin, stdout = kstdout, stderr = kstderr),
+                    wait = false)
+        process_running(kproc) || error("There was a problem startink up kaleido.")
+        close(kstdout.in)
+        close(kstderr.in)
+        close(kstdin.out)
+        Base.start_reading(kstderr.out)
+        P.stdin = kstdin
+        P.stdout = kstdout
+        P.stderr = kstderr
+        P.proc = kproc
+
+        # read startup message and check for errors
+        res = readline(P.stdout)
+        if length(res) == 0
+            error("Could not start Kaledio process")
+        end
+
+        js = JSON.parse(res)
+        if get(js, "code", 0) != 0
+            error("Could not start Kaledio process")
+        end
+    catch
+        @warn "Kaledio is not available on this system. Julia will be unable to produce any plots."
+    end
+    nothing
+end
+
+function savefig(
+        p::Plot;
+        width::Union{Nothing,Int}=nothing,
+        height::Union{Nothing,Int}=nothing,
+        scale::Union{Nothing,Real}=nothing,
+        format::String="png"
+    )::Vector{UInt8}
+    if !(format in ALL_FORMATS)
+        error("Unknown format $format. Expected one of $ALL_FORMATS")
+    end
+
+    # construct payload
+    _get(x, def) = x === nothing ? def : x
+    payload = Dict(
+        :width => _get(width, 700),
+        :height => _get(height, 500),
+        :scale => _get(scale, 1),
+        :format => format,
+        :data => p
+    )
+
+    _ensure_kaleido_running()
+
+    # convert payload to vector of bytes
+    bytes = transcode(UInt8, JSON.json(payload))
+    write(P.stdin, bytes)
+    write(P.stdin, transcode(UInt8, "\n"))
+    flush(P.stdin)
+
+    # read stdout and parse to json
+    res = readline(P.stdout)
+    js = JSON.parse(res)
+
+    # check error code
+    code = get(js, "code", 0)
+    if code != 0
+        msg = get(js, "message", nothing)
+        error("Transform failed with error code $code: $msg")
+    end
+
+    # get raw image
+    img = String(js["result"])
+
+    # base64 decode if needed, otherwise transcode to vector of byte
+    if format in TEXT_FORMATS
+        return transcode(UInt8, img)
+    else
+        return base64decode(img)
+    end
+end
+
+function savefig(io::IO,
+        p::Plot;
+        width::Union{Nothing,Int}=nothing,
+        height::Union{Nothing,Int}=nothing,
+        scale::Union{Nothing,Real}=nothing,
+        format::String="png")
+
+    format == "html" && return savehtml(io, p)
+
+    bytes = savefig(p, width=width, height=height, scale=scale, format=format)
+    write(io, bytes)
+end
+
+"""
+    savefig(p::Plot, fn::AbstractString; format=nothing, scale=nothing,
+    width=nothing, height=nothing)
+Save a plot `p` to a file named `fn`. If `format` is given and is one of
+(png, jpeg, webp, svg, pdf, eps), it will be the format of the file. By
+default the format is guessed from the extension of `fn`. `scale` sets the
+image scale. `width` and `height` set the dimensions, in pixels. Defaults
+are taken from `p.layout`, or supplied by plotly
+"""
+function savefig(
+        p::Plot, fn::AbstractString;
+        format::Union{Nothing,String}=nothing,
+        width::Union{Nothing,Int}=nothing,
+        height::Union{Nothing,Int}=nothing,
+        scale::Union{Nothing,Real}=nothing,
+    )
+    ext = split(fn, ".")[end]
+    if format === nothing
+        format = String(ext)
+    end
+
+    open(fn, "w") do f
+        savefig(f, p; format=format, scale=scale, width=width, height=height)
+    end
+    return fn
+end
+
+_kaleido_running() = isopen(P.stdin) && process_running(P.proc)
+_ensure_kaleido_running() = !_kaleido_running() && _restart_kaleido_process()

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -24,7 +24,9 @@ function _start_kaleido_process()
     try
         BIN = let
             art = artifact"kaleido"
-            `$(joinpath(art, "kaleido", "kaleido")) plotly --disable-gpu`
+            suff = Sys.isunix() ? "" : ".cmd"
+            cmd = joinpath(art, "kaleido", "kaleido$(suff)")
+            `$(cmd) plotly --disable-gpu`
         end
         kstdin = Pipe()
         kstdout = Pipe()

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -1,4 +1,7 @@
-const BIN = `$(joinpath(artifact"kaleido", "kaleido", "kaleido")) plotly --disable-gpu`
+const BIN = let
+    art = artifact"kaleido"
+    `$(joinpath(art, "kaleido", "kaleido")) plotly --disable-gpu`
+end
 
 mutable struct Pipes
     stdin::Pipe

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -1,8 +1,3 @@
-const BIN = let
-    art = artifact"kaleido"
-    `$(joinpath(art, "kaleido", "kaleido")) plotly --disable-gpu`
-end
-
 mutable struct Pipes
     stdin::Pipe
     stdout::Pipe
@@ -27,6 +22,10 @@ end
 function _start_kaleido_process()
     global P
     try
+        BIN = let
+            art = artifact"kaleido"
+            `$(joinpath(art, "kaleido", "kaleido")) plotly --disable-gpu`
+        end
         kstdin = Pipe()
         kstdout = Pipe()
         kstderr = Pipe()


### PR DESCRIPTION
@staticfloat thanks for trying to help me over in PlotlyJS.jl

I am learning the artifacts system.

I've tried to get things started over here using plotly's new static image exporter kaleido.

With the config in this repo, when I try to do `using PlotlyBase` I get 

```
julia> using PlotlyBase
[ Info: Precompiling PlotlyBase [a03496cd-edff-5a9b-9e67-9cda94a718b5]
ERROR: LoadError: LoadError: LoadError: Cannot locate '(Julia)Artifacts.toml' file when attempting to use artifact 'kaleido' in 'PlotlyBase'
Stacktrace:
```

Any idea how to fix this?

Note I did `]dev PlotlyBase`, checked out ~/.julia/dev/PlotlyBase to the kaleido dir, and then activated the project.  