### PR TITLE
Update dataframes_api.jl

### DIFF
--- a/src/dataframes_api.jl
+++ b/src/dataframes_api.jl
@@ -38,7 +38,10 @@ different mean for each group.
 function GenericTrace(df::DataFrames.AbstractDataFrame; group=nothing, kind="scatter", kwargs...)
     d = Dict{Symbol,Any}(kwargs)
     if _has_group(df, group)
-        _traces = map(dfg -> GenericTrace(dfg; kind=kind, name=_group_name(dfg, group), kwargs...), DataFrames.groupby(df, group))
+        _traces = []
+        for dfg in DataFrames.groupby(df, group)
+            push!(_traces,  GenericTrace(dfg; kind=kind, name=_group_name(dfg, group), kwargs...))
+        end
         return GenericTrace[t for t in _traces]
     else
         if (group !== nothing)


### PR DESCRIPTION
map over GroupedDataFrame does not work anymore with newer versions of DataFrame.
Could certainly made more efficient, but as I am not 100% sure what I am doing, I wanted to change as few as possible.
