### PR TITLE
Fixes "Kaleido is not available" warning on Windows

### DIFF
--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -32,7 +32,7 @@ function _start_kaleido_process()
                 # Windows
                 joinpath(art, "kaleido.cmd")
             end
-            no_sandbox =  "--no-sandbox"
+            no_sandbox = "--no-sandbox"
             Sys.isapple() ? `$(cmd) plotly --disable-gpu --single-process` : `$(cmd) plotly --disable-gpu $(no_sandbox)`
         end
         kstdin = Pipe()

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -32,7 +32,7 @@ function _start_kaleido_process()
                 # Windows
                 joinpath(art, "kaleido.cmd")
             end
-            no_sandbox = Sys.islinux() ? "--no-sandbox" : ""
+            no_sandbox = Sys.islinux() || Sys.iswindows() ? "--no-sandbox" : ""
             Sys.isapple() ? `$(cmd) plotly --disable-gpu --single-process` : `$(cmd) plotly --disable-gpu $(no_sandbox)`
         end
         kstdin = Pipe()

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -32,7 +32,7 @@ function _start_kaleido_process()
                 # Windows
                 joinpath(art, "kaleido.cmd")
             end
-            no_sandbox = Sys.islinux() || Sys.iswindows() ? "--no-sandbox" : ""
+            no_sandbox =  "--no-sandbox"
             Sys.isapple() ? `$(cmd) plotly --disable-gpu --single-process` : `$(cmd) plotly --disable-gpu $(no_sandbox)`
         end
         kstdin = Pipe()


### PR DESCRIPTION
When we add PlotlyBase.jl to Windows SYSIMG on Julia v1.6.1, we encounter following warning during REPL startup, this PR fixes this warning.

```
┌ Warning: Kaleido is not available on this system. Julia will be unable to save images of any plots.
└ @ PlotlyBase C:\Users\julia\.julia\packages\PlotlyBase\GDbp9\src\kaleido.jl:65
┌ Warning: ErrorException("Could not start Kaleido process")
└ @ PlotlyBase C:\Users\julia\.julia\packages\PlotlyBase\GDbp9\src\kaleido.jl:66

               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.1 (2021-04-23)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |
julia>
```
Relevant issues and PR's:-  

* https://github.com/sglyon/PlotlyBase.jl/pull/46
* https://github.com/sglyon/PlotlyBase.jl/issues/45