### PR TITLE
A little less backdoor-y support for JSON3

### DIFF
--- a/src/json3.jl
+++ b/src/json3.jl
@@ -1,4 +1,4 @@
-# const StructTypes = JSON3.StructTypes
+const StructTypes = JSON3.StructTypes
 
 # StructTypes.StructType(::Type{T}) where T <: HasFields = StructTypes.DictType()
 # StructTypes.construct(::Type{T}, x::AbstractDict; kw...) where T <: HasFields = T(_symbol_dict(x); kw...)
@@ -6,6 +6,5 @@
 # StructTypes.StructType(::Type{T}) where T <: Union{Plot,PlotConfig} = StructTypes.Mutable()
 # StructTypes.omitempties(::Type{PlotConfig}) = fieldnames(PlotConfig)
 
-# backdoor to apply things like templates
-JSON3.write(io::IO, p::Plot) = JSON.print(io, p)
-JSON3.write(p::Plot) = JSON.json(p)
+StructTypes.StructType(::Type{<:PlotlyBase.Plot}) = JSON3.RawType()
+JSON3.rawbytes(plot::PlotlyBase.Plot) = codeunits(JSON.json(plot))


### PR DESCRIPTION
This allows serialisable objects containing plots to be serialized, e.g. `Dict(:plot => plot(...))`

I'm afraid I missed some reason why it was implemented the way it was, but I thought I'd find out by creating a PR 😁 