### PR TITLE
add json3 and print definitions and for PlotConfig

### DIFF
--- a/src/json.jl
+++ b/src/json.jl
@@ -58,7 +58,7 @@ function JSON.lower(p::Plot)
 end
 
 # Let string interpolation stringify to JSON format
-Base.print(io::IO, a::Union{Shape,GenericTrace,PlotlyAttribute,Layout,Plot}) = print(io, JSON.json(a))
+Base.print(io::IO, a::Union{Shape,GenericTrace,PlotlyAttribute,Layout,Plot,PlotConfig}) = print(io, JSON.json(a))
 Base.print(io::IO, a::Vector{T}) where {T <: GenericTrace} = print(io, JSON.json(a))
 
 GenericTrace(d::AbstractDict{Symbol}) = GenericTrace(pop!(d, :type, "scatter"), d)

--- a/src/json3.jl
+++ b/src/json3.jl
@@ -7,7 +7,7 @@ const StructTypes = JSON3.StructTypes
 # StructTypes.omitempties(::Type{PlotConfig}) = fieldnames(PlotConfig)
 
 StructTypes.StructType(::Type{<:PlotlyBase.Plot}) = JSON3.RawType()
-JSON3.rawbytes(plot::PlotlyBase.Plot) = codeunits(JSON.json(plot))
-
 StructTypes.StructType(::Type{<:HasFields}) = JSON3.RawType()
-JSON3.rawbytes(x::HasFields) = codeunits(JSON.json(x))
+StructTypes.StructType(::Type{PlotConfig}) = JSON3.RawType()
+
+JSON3.rawbytes(x::Union{PlotlyBase.Plot,HasFields,PlotConfig}) = codeunits(JSON.json(x))


### PR DESCRIPTION
I just realised that `HasFields` does not include `PlotConfig`. (Obviously that's correct as it doesn't have fields)

Nevertheless, I propose to define `JSON3.write()` and `print()` for the  `PlotConfig` type in the same manner as for `HasFields` types. This way configs could be passed separately via JSON for applications like `Stipple.jl`.