### PR TITLE
Make Colors.jl a direct dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 version = "0.8.19"
 
 [deps]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
@@ -27,7 +28,6 @@ Requires = "1"
 julia = "1.4"
 
 [extensions]
-ColorsExt = "Colors"
 DataFramesExt = "DataFrames"
 DistributionsExt = "Distributions"
 IJuliaExt = "IJulia"
@@ -45,7 +45,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Colors", "DataFrames", "DelimitedFiles", "JSON3", "Dates", "Test"]
 
 [weakdeps]
-Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"

--- a/ext/ColorsExt.jl
+++ b/ext/ColorsExt.jl
@@ -1,8 +1,0 @@
-module ColorsExt
-
-isdefined(Base, :get_extension) ? (using Colors) : (using ..Colors)
-using PlotlyBase
-
-PlotlyBase._json_lower(a::Colorant) = "#$(hex(a, :auto))"
-
-end

--- a/src/PlotlyBase.jl
+++ b/src/PlotlyBase.jl
@@ -6,6 +6,7 @@ using DocStringExtensions
 using UUIDs
 using Dates
 using Logging
+using Colors
 using ColorSchemes
 using Parameters
 
@@ -159,7 +160,6 @@ function __init__()
     @require IJulia="7073ff75-c697-5162-941a-fcdaad2a7d2a" include("../ext/IJuliaExt.jl")
     @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" include("../ext/DataFramesExt.jl")
     @require Distributions="31c24e10-a181-5473-b8eb-7969acd0382f" include("../ext/DistributionsExt.jl")
-    @require Colors="5ae59095-9a9b-59fe-a467-6f913c188581" include("../ext/ColorsExt.jl")
     @require JSON3="0f8b85d8-7281-11e9-16c2-39a750bddbf1" include("../ext/JSON3Ext.jl")
 end
 end # @static

--- a/src/json.jl
+++ b/src/json.jl
@@ -9,6 +9,9 @@ _json_lower(x::Union{Tuple,AbstractArray}) = _json_lower.(x)
 _json_lower(d::Dict) = Dict{Any,Any}(k => _json_lower(v) for (k, v) in pairs(d))
 _json_lower(a::HasFields) = Dict{Any,Any}(k => _json_lower(v) for (k, v) in pairs(a.fields))
 _json_lower(c::Cycler) = c.vals
+
+_json_lower(c::Colorant) = string("#", Colors.hex(c, :auto))
+
 function _json_lower(c::ColorScheme)::Vector{Tuple{Float64,String}}
     N = length(c.colors)
     map(ic -> ((ic[1] - 1) / (N - 1), _json_lower(ic[2])), enumerate(c.colors))


### PR DESCRIPTION
Currently, *Colors.jl* is a weak dependency, and the user needs `using Colors` to enable *ColorsExt* extension, which sole purpose is to define `_json_lower(c::Colorant)`.
However, *PlotlyBase.jl* already has *ColorSchemes.jl* as a direct dependency and defines `_json_lower(::ColorScheme)` in the main module.
But the latter method needs `_json_lower(::Colorant)` to work.

So, making `Colors.jl` a direct dependency of `PlotlyBase.jl` would simplify things a bit. It would not increase the "dependencies burden" of `PlotlyBase.jl` since `Colors.jl` is already a direct dependency of `ColorSchemes.jl`.

Also, it should solve the error
```
MethodError: Cannot `convert` an object of type JSON.Writer.CompositeTypeWrapper{RGB{Float64}} to an object of type String
```
which I am getting despite `using Colors` in my user project.