### PR TITLE
Fix `IJuliaExt.display_dict` for julia 1.11

### DIFF
--- a/ext/IJuliaExt.jl
+++ b/ext/IJuliaExt.jl
@@ -10,7 +10,7 @@ function IJulia.display_dict(p::Plot)
         "text/html" => let
             buf = IOBuffer()
             show(buf, MIME("text/html"), p, include_plotlyjs="require")
-            String(resize!(buf.data, buf.size))
+            String(take!(buf))
         end
     )
 end


### PR DESCRIPTION
Use `IOBuffer` without relying on implementation details. Should fix https://github.com/sglyon/PlotlyBase.jl/issues/108