### PR TITLE
Suppport dictionary-valued attributes

### DIFF
--- a/test/traces.jl
+++ b/test/traces.jl
@@ -215,6 +215,24 @@ end
 
     # error on 5 levels
     @test_throws MethodError gt["marker.colorbar.tickfont.family.foo"] = :bar
+
+    @testset "_ASSOCIATIVE_ATTRS" begin
+        axis = attr(type = "category", categoryorder = "array", categoryarray = ["a", "b", "c"],
+                    labelalias = Dict("a" => "A", "b" => "B", "c" => "C"))
+        # associative attributes can have Dictionary values, and are exempt from nest attr() logic
+        @test haskey(axis, :labelalias)
+        @test axis["labelalias"] isa Dict
+        axis[:labelalias] = Dict("a" => "apple", "b" => "banana", "c" => "cherry")
+        @test !haskey(axis[:labelalias], :a)
+        @test axis[:labelalias]["a"] == "apple"
+
+        geotrace = scattergeo(geojson = Dict("a" => 1, "b" => "x"))
+        @test haskey(geotrace, :geojson)
+        @test geotrace[:geojson] isa Dict
+
+        # assigning dicts with string keys to anything else is an error
+        @test_throws MethodError scatter(marker = Dict("a" => 1, "b" => "x"))
+    end
 end
 
 @testset "testing underscore constructor" begin


### PR DESCRIPTION
The values of some *plotly.js* attributes could be dictionaries (i.e. JSON).
*PlotlyBase.jl* already partially supports that for `geojson` (of `scattergeo` trace).
Recent *plotly.js* versions has added support for axes [label aliases](https://plotly.com/javascript/reference/layout/xaxis/#layout-xaxis-labelalias), which are also dictionaries.
It allows to improve the display of axes ticks, while keeping the actual plot data lean.

The problem with the current *PlotlyBase* logic is that it treats any dictionary values as nested attributes.
The PR fixes that by defining the list of attributes that could be dictionaries (`_ASSOCIATIVE_ATTRS`) and disabling nested *attr* logic for them.
It also extends the support for dict-valued attributes for symbol-valued keys (currently only `"geojson",` but not `:geojson` is supported)
as well as for nested keys.
