### PR TITLE
fix IJuliaExt

### DIFF
--- a/ext/IJuliaExt.jl
+++ b/ext/IJuliaExt.jl
@@ -5,11 +5,11 @@ using PlotlyBase
 
 function IJulia.display_dict(p::Plot)
     Dict(
-        "application/vnd.plotly.v1+json" => JSON.lower(p),
+        "application/vnd.plotly.v1+json" => PlotlyBase.JSON.lower(p),
         "text/plain" => sprint(show, "text/plain", p),
         "text/html" => let
             buf = IOBuffer()
-            show(buf, MIME("text/html"), p, include_plotlyjs="require")
+            show(buf, MIME("text/html"), p)
             String(take!(buf))
         end
     )


### PR DESCRIPTION
The IJuliaExt in its current form fails as the JSON dependency is directly called without being loaded in the extension module. This PR mainly prepends the PlotlyBase module to the `JSON.lower` call.

Additionally, I found that at least in Google Colab (didn't try on local IJulia) the `include_plotlyjs=require` fails on the javascript side with an error hinting at `missing require`. I did remove the kwarg as the `cdn` fallback works fine, but if for some reason the require was needed for some specific purpose I can try to have a look at how and if it can be put back.

Link to the Google colab notebook used to test:
https://colab.research.google.com/drive/1Ehx_z35JqmwjvqN3ZxupyxynziqHzE2y?usp=sharing