### PR TITLE
Fix error in DataFramesExt.jl

### DIFF
--- a/ext/DataFramesExt.jl
+++ b/ext/DataFramesExt.jl
@@ -6,7 +6,7 @@ isdefined(Base, :get_extension) ? (using DocStringExtensions) : (using ..DocStri
 
 import PlotlyBase: _Maybe, PlotlyAttribute, _TRACE_TYPES,
                    GenericTrace, Plot, setifempty!, _isempty, _obtain_setindex_val,
-                   _get_default_seq
+                   _get_default_seq, _symbol_dict
 
 using Base:Symbol
 # utilities


### PR DESCRIPTION
The `_symbol_dict` function was not imported from PlotlyBase in the extension module and causes an error (discovered in https://github.com/JuliaPluto/PlutoPlotly.jl/issues/62#issuecomment-2783230974)

This code path is only traversed with a non-custom `labels` kwarg which is probably not covered by tests and it was not spotted.