### PR TITLE
Use full module name when adding methods from Extension

### DIFF
--- a/ext/DistributionsExt.jl
+++ b/ext/DistributionsExt.jl
@@ -7,12 +7,12 @@ _strip_module(s) = split(s, '.', limit=2)[end]
 _strip_type_param(s) = replace(s, r"{.+?}" => "")
 _clean_name(d::Distributions.Distribution) = _strip_module(_strip_type_param(repr(d)))
 
-function scatter(d::Distributions.ContinuousUnivariateDistribution)
+function PlotlyBase.scatter(d::Distributions.ContinuousUnivariateDistribution)
     ls(a, b, c) = range(a, stop=b, length=c)
     x = ls(Distributions.quantile.([d], [0.01, 0.99])..., 100)
     trace = scatter(x=x, y=Distributions.pdf.([d], x), name=_clean_name(d))
 end
 
-Plot(d::Distributions.UnivariateDistribution...) = Plot(collect(map(scatter, d)))
+PlotlyBase.Plot(d::Distributions.UnivariateDistribution...) = Plot(collect(map(scatter, d)))
 
 end


### PR DESCRIPTION
Extending the `Plot` type constructor from the extension without specifying the full module name gives a warning in 1.12:

<img width="1162" height="260" alt="image" src="https://github.com/user-attachments/assets/f9415552-d967-40e7-a550-57df0c8eaf65" />

This PR adds the full module name when adding methods to `PlotlyBase` functions from the extension